### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ios_build.yml
+++ b/.github/workflows/ios_build.yml
@@ -1,4 +1,6 @@
 name: Flutter CI iOS
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/hprs-in/pslabel_app/security/code-scanning/1](https://github.com/hprs-in/pslabel_app/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow. Since the workflow primarily involves checking out the code and building an iOS app, it only needs `contents: read` permissions. This ensures that the workflow cannot perform any unintended write operations.

The `permissions` block will be added immediately after the `name` field at the top of the file to apply these permissions to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
