### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -1,4 +1,6 @@
 name: Flutter CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/hprs-in/pslabel_app/security/code-scanning/2](https://github.com/hprs-in/pslabel_app/security/code-scanning/2)

To fix the issue, add a `permissions` block at the root of the workflow file to explicitly limit the permissions of the `GITHUB_TOKEN`. Based on the tasks performed in the workflow, the minimal required permission is `contents: read`. This ensures that the workflow adheres to the principle of least privilege while still functioning correctly.

The `permissions` block should be added directly under the `name` key in the workflow file to apply to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
